### PR TITLE
Bugfix of issue #102: do not auto wrap long lines

### DIFF
--- a/src/Processor/LatexToUnicodeProcessor.php
+++ b/src/Processor/LatexToUnicodeProcessor.php
@@ -66,6 +66,7 @@ class LatexToUnicodeProcessor
             return $this->pandoc->runWith($text, [
                 'from' => 'latex',
                 'to' => 'plain',
+                'wrap' => 'none',
             ]);
         } catch (PandocException $exception) {
             throw new ProcessorException(sprintf('Error while processing LaTeX to Unicode: %s', $exception->getMessage()), 0, $exception);


### PR DESCRIPTION
This change disables auto-wrapping of field content that is longer than 72 characters with newline characters.